### PR TITLE
Added option to change helm repo path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,4 +4,6 @@ helm_version: 'v3.2.1'
 helm_platform: linux
 helm_arch: amd64
 
+helm_repo_path: "https://get.helm.sh"
+
 helm_bin_path: /usr/local/bin/helm

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Download helm.
   unarchive:
-    src: "{{ helm_repo_path }}helm-{{ helm_version }}-{{ helm_platform }}-{{ helm_arch }}.tar.gz"
+    src: "{{ helm_repo_path }}/helm-{{ helm_version }}-{{ helm_platform }}-{{ helm_arch }}.tar.gz"
     dest: /tmp
     remote_src: true
     mode: 0755

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Download helm.
   unarchive:
-    src: https://get.helm.sh/helm-{{ helm_version }}-{{ helm_platform }}-{{ helm_arch }}.tar.gz
+    src: "{{ helm_repo_path }}helm-{{ helm_version }}-{{ helm_platform }}-{{ helm_arch }}.tar.gz"
     dest: /tmp
     remote_src: true
     mode: 0755


### PR DESCRIPTION
Sometimes is need to change repo path, when direct access to internet is not possible. This option will give option to replace repo path with proxy path (for example Nexus proxy repository path)