### PR TITLE
fix: install packages required for unarchive

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,12 @@
   changed_when: false
   register: helm_existing_version
 
+- name: Install required packages.
+  package:
+    name:
+      - tar
+      - unzip
+
 - name: Download helm.
   unarchive:
     src: "{{ helm_repo_path }}/helm-{{ helm_version }}-{{ helm_platform }}-{{ helm_arch }}.tar.gz"


### PR DESCRIPTION
Without this patch, I was getting this error on some machines:

    fatal: [server1]: FAILED! => {"changed": false, "msg": "Failed to find handler for \"/root/.ansible/tmp/ansible-tmp-1655886302.6411574-54535-279760253748649/helm-v3.7.2-linux-amd64.tar7saeun_5.gz\". Make sure the required command to extract the file is installed.\nUnable to find required 'unzip' or 'zipinfo' binary in the path.\nUnable to find required 'gtar' or 'tar' binary in the path"}

@moduon MT-904